### PR TITLE
Support metrics in filtering expressions.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 This file documents all notable changes to juttle-aws-adapter. The release numbering uses [semantic versioning](http://semver.org).
 
+## 0.2.0
+
+### Major Changes
+- Modify filtering expression to support metrics in addition to products/items.
+- Item/Metric filtering can be expressed using ANDs between products and items/metrics.
+
 ## 0.1.2
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Other boolean logic such as NOT is not supported.
 
 Here are some example filter expressions:
 
-```Javascript
+```Juttle
 // A single product
 read cloudwatch product="EC2" | ...
 

--- a/lib/CloudWatchMon.js
+++ b/lib/CloudWatchMon.js
@@ -10,6 +10,8 @@ class CloudWatchMon {
         this._AWS = options.AWS;
         this._logger = options.logger;
 
+        this._products = options.products;
+
         this._cw_client = Promise.promisifyAll(new this._AWS.CloudWatch());
         this._period = options.period;
         this._statistics = options.statistics;
@@ -18,25 +20,25 @@ class CloudWatchMon {
 
         this._nonzero_only_metrics = ['StatusCheckFailed_System', 'StatusCheckFailed_Instance', 'StatusCheckFailed'];
 
-        // This is an array of objects containing the product name,
-        // item name and list of item ids. If the list of item ids is
-        // empty, fetch cloudwatch metrics for all items for the given
-        // product.
-        this._monitor = options.monitor;
+        // This is an list of conditions, returned by
+        // FilterCloudwatchCompiler. Each item in the list specifies a
+        // product, set of items, and/or set of metrics for which to
+        // fetch CloudWatch information.
+        this._conditions = options.conditions;
     }
 
     // Poll the CloudWatch API and return a list of events and metrics.
     poll(from, to) {
-        this._logger.debug('Polling CloudWatch for ' + this._monitor.length + ' AWS Products');
-        this._logger.debug('Polling details: ', this._monitor);
+        this._logger.debug('Polling CloudWatch for ' + this._conditions.length + ' Conditons');
+        this._logger.debug('Polling details: ', this._conditions);
 
-        return Promise.map(this._monitor, (product) => {
-            return this._get_metrics_for(product, from, to);
-        }).then((plugin_results) => {
-            return _.sortBy(_.flatten(plugin_results), 'time');
+        return Promise.map(this._conditions, (cond) => {
+            return this._get_metrics_for(cond, from, to);
+        }).then((results) => {
+            return _.sortBy(_.flatten(results), 'time');
         }).catch((e) => {
             this._logger.error('Could not fetch information from CloudWatch: ' + e);
-            return [];
+            throw e;
         });
 
     }
@@ -50,7 +52,7 @@ class CloudWatchMon {
     // the metrics that exist for the items, and a second call to
     // getMetricStatistics to get the values for the metrics.
 
-    _get_metrics_for(product, from, to) {
+    _get_metrics_for(cond, from, to) {
         // If there is not an explicit list of items to track for the
         // given product, the dimension is only the item name
         // (e.g. EC2InstanceId). Otherwise, there are multiple
@@ -58,15 +60,15 @@ class CloudWatchMon {
 
         let global_opts = {
             Dimensions: [ {
-                Name: product.item_name
+                Name: this._products[cond.product]
             } ]
         };
 
-        if (product.item_ids.length > 0) {
+        if (cond.item.length > 0) {
             global_opts = {
-                Dimensions: _.map(product.item_ids, (item_id) => {
+                Dimensions: _.map(cond.item, (item_id) => {
                     return {
-                        Name: product.item_name,
+                        Name: this._products[cond.product],
                         Value: item_id
                     };
                 })
@@ -98,7 +100,18 @@ class CloudWatchMon {
         };
 
         return list_metrics_batch(undefined).then(() => {
-            this._logger.debug(`Found ${metrics.length} metrics x dimensions to fetch for ${product.product}`);
+
+            this._logger.debug(`Found ${metrics.length} metrics`);
+
+            // If the list of metrics in the condition is non-empty, only include those metrics.
+            if (cond.metric.length > 0) {
+                metrics = _.filter(metrics, (metric) => {
+                    return _.contains(cond.metric, metric.MetricName);
+                });
+                this._logger.debug(`Filtered down to ${metrics.length} metrics`);
+            }
+
+            this._logger.debug(`Found ${metrics.length} metrics x dimensions to fetch for ${cond.product}`);
 
             return Promise.map(metrics, (metric) => {
                 // Occasionally the Dimensions array will be empty. In
@@ -131,7 +144,7 @@ class CloudWatchMon {
                             return {
                                 time: JuttleMoment.parse(datapoint.Timestamp),
                                 metric_type: 'AWS CloudWatch',
-                                product: product.product,
+                                product: cond.product,
                                 namespace: metric.Namespace,
                                 name: metric.MetricName,
                                 dimension: metric.Dimensions[0].Name,

--- a/lib/filter-cloudwatch-compiler.js
+++ b/lib/filter-cloudwatch-compiler.js
@@ -18,21 +18,25 @@ var _ = require('underscore');
 // control what metrics to fetch.
 //
 // Here's the supported filtering expression:
-//  The expression can be a variable length list of simple key=value
-//      pairs, separated by OR.
-//    - No other boolean logic (ANDs, NOT, etc) is allowed.
-//    - No comparisons other than '=' between keys and
-//      values are allowed.
-//  The possible values for keys can be:
+//  - The expression is a variable length list of conditions joined by
+//    OR. A condition is a product, a product + metric, a product
+//    + item, or a product + metric + item.
+//  - A product, metric, or item is expressed using key=value. No comparisons
+//    other than '=' between keys and values are allowed.
+//  - The possible values for keys are:
 //    - 'product': specifying a specific product such as 'EC2', 'ELB',
-//                 etc.  If multiple products are specified, the
-//                 adapter fetches information for both sets of
-//                 products.
-//    - 'item': specifying a specific item. This should be expressed
-//              as '<product>:<item name>', for example
-//              'EC2:i-ca915d10', 'EBS:vol-7e9cf971', etc. If any item
-//              field is specified, the data returned is CloudWatch
-//              metrics for the specified item.
+//                 etc.
+//    - 'item': specifying a specific item (i.e. "i-cc696a17" for EC2,
+//              "vol-56130db1" for EBS). If any item field is
+//              specified, the data returned is CloudWatch metrics for
+//              the specified item.
+//    - 'metric': specifying a specific metric. If any metric field is
+//              specified, only those CloudWatch metrics are returned.
+//    - A product + metric can be expressed using AND (product='EC2'
+//      AND metric='CPUUtilization') or using a concise format
+//      (metric='EC2:CPUUtilization')
+//    - AND can only be used to combine one product, one metric, and/or one item.
+//    - Other boolean logic is not supported.
 
 var FilterCloudWatchCompiler = ASTVisitor.extend({
     initialize: function(options) {
@@ -48,11 +52,17 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
     },
 
     compile: function(node) {
-        return this.visit(node);
+        let conds = this.visit(node);
+
+        return this.merge(conds);
     },
 
     visitStringLiteral: function(node) {
         return node.value;
+    },
+
+    visitSimpleFilterTerm: function(node) {
+        this.throwUnsupportedFilter(node.location, 'simple filter terms');
     },
 
     visitUnaryExpression: function(node) {
@@ -68,80 +78,187 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
         }
     },
 
+    // Build up a list of conditions that control what metrics to
+    // fetch. Each item in the array specifies conditions on:
+    //  - product: an AWS product.
+    //  - item: a list of item ids.
+    //  - metric: a list of metrics to fetch.
+    //
+    // While parsing the filter expression any of these can not yet
+    // defined (undefined for product, an empty array for
+    // items/metrics).
+    //
+    // ANDs are used to combine incomplete conditions and ORs are used
+    // to add to the list of conditions.
+
     visitBinaryExpression: function(node) {
         var left, right, ret;
 
         switch (node.operator) {
 
+            case 'AND':
+                left = this.visit(node.left);
+                right = this.visit(node.right);
+
+                // You can only combine single conditions
+                if (left.length > 1 || right.length > 1) {
+                    this.throwUnsupportedFilter(node.location, 'AND between anything other than simple conditions');
+                }
+                left = left[0];
+                right = right[0];
+
+                // You can only combine items if one of the products/items/metrics
+                // is wildcarded (undefined for products, an empty array for items/metrics).
+                if (left.product !== undefined &&
+                    right.product !== undefined) {
+                    this.throwUnsupportedFilter(node.location, 'AND between products');
+                }
+
+                if ((left.item.length > 0 && right.item.length > 0)) {
+                    this.throwUnsupportedFilter(node.location, 'AND between items');
+                }
+
+                if ((left.metric.length > 0 && right.metric.length > 0)) {
+                    this.throwUnsupportedFilter(node.location, 'AND between metrics');
+                }
+
+                // merge the two halves by combining the objects.
+                ret = [{
+                    product: (left.product === undefined ? right.product : left.product),
+                    metric: _.union(left.metric, right.metric),
+                    item: _.union(left.item, right.item),
+                }];
+
+                break;
+
             case 'OR':
                 left = this.visit(node.left);
                 right = this.visit(node.right);
 
-                ret = _.extend({}, right, left);
+                // Just concatenate the conditions. We'll try to merge at the end.
+                ret = left.concat(right);
 
-                // The extend() didn't actually handle the case where
-                // left and right both had a value for the same key.
-                // Handle that here by merging the two arrays.
-                ret = _.mapObject(ret, function(val, key) {
-                    return _.union(val, right[key]);
-                });
-
-                return ret;
+                break;
 
             case '==':
                 left = this.visit(node.left);
                 right = this.visit(node.right);
 
-                // Left *must* be either 'item' or 'product'. When
-                // left is 'product', right must be one of the
-                // supported AWS products.
-                if (left !== 'item' && left !== 'product') {
+                // Left *must* be either 'item', 'product', or
+                // 'metric'. When left is 'product', right must be one
+                // of the supported AWS products.
+                if (left !== 'item' && left !== 'product' && left !== 'metric') {
                     this.throwUnsupportedFilter(node.location, 'condition ' + left);
                 }
 
-                if (left === 'product') {
-                    if (! _.contains(this.supported_products, right)) {
-                        this.throwUnsupportedFilter(node.location, 'product ' + right);
-                    }
+                // for items/metrics, support a shorthand format '<aws
+                // product>:<item name>'. <aws product> must be one of
+                // the supported products.
+                let product = undefined;
+                let value = right;
 
-                    ret = {};
-                    ret[right] = [];
-                    return ret;
-
-                } else {
-
-                    // Item values must have a specific format '<aws
-                    // product>:<item name>', so ensure that there
-                    // is an <aws product> and that it matches one of
-                    // the supported products.
-                    if (right.indexOf(':') === -1) {
-                        this.throwUnsupportedFilter(node.location,
-                                                    'item value not having format <aws product>:<item name>');
-                    }
-
-                    var parts = right.split(':', 2);
-                    var product = parts[0];
-                    var item = parts[1];
-
-                    if (! _.contains(this.supported_products, product)) {
-                        this.throwUnsupportedFilter(node.location, 'product ' + product);
-                    }
-
-                    ret = {};
-                    ret[product] = [item];
-                    return ret;
+                if (right.indexOf(':') >= 0) {
+                    let parts = right.split(':', 2);
+                    product = parts[0];
+                    value = parts[1];
                 }
+
+                ret = {
+                    product: product,
+                    item: [],
+                    metric: []
+                };
+
+                if (left === 'product') {
+                    ret.product = value;
+                } else {
+                    ret[left] = [value];
+                }
+
+                // If product was set, it can only be a supported product
+                if (ret.product && ! _.contains(this.supported_products, ret.product)) {
+                    this.throwUnsupportedFilter(node.location, 'product ' + ret.product);
+                }
+
+                ret = [ret];
 
                 break;
 
             default:
                 this.throwUnsupportedFilter(node.location, 'operator ' + node.operator);
         }
+
+        return ret;
     },
 
     visitExpressionFilterTerm: function(node) {
         return this.visit(node.expression);
-    }
+    },
+
+    // Not inherited from ASTVisitor below here.
+    can_merge(cond1, cond2) {
+
+        // In order to merge, the products must be the same.
+        if (cond1.product !== cond2.product) {
+            return false;
+        }
+
+        // If one condition has a zero-length metric or item list, the
+        // other must have a zero length list as well.
+        if ((cond1.item.length === 0 && cond2.item.length !== 0) ||
+            (cond1.metric.length === 0 && cond2.metric.length !== 0)) {
+            return false;
+        }
+
+        // It's possible to merge the two conditions if they both have
+        // item restrictions or both have metric restrictions, but not
+        // a mix.
+        if (cond1.item.length + cond2.item.length > 0 &&
+            cond1.metric.length + cond2.metric.length > 0) {
+            return false;
+        }
+
+        // The conditions can be merged.
+        return true;
+    },
+
+    // Given a list of conditions, try to merge them. This involves
+    // finding conditions where the products are the same and the set
+    // of metrics/items do not overlap.
+
+    merge(conds) {
+        let merged = [];
+
+        if (conds === undefined) {
+            return conds;
+        }
+
+        for(let cond of conds) {
+            let i;
+            for(i=0; i < merged.length; i++) {
+                if (this.can_merge(merged[i], cond)) {
+                    merged[i].item = _.union(merged[i].item, cond.item);
+                    merged[i].metric = _.union(merged[i].metric, cond.metric);
+                    break;
+                }
+            }
+            if (i === merged.length) {
+                // Couldn't merge with any existing condition, just
+                // add it to the end.
+                merged.push(cond);
+            }
+        }
+
+        // Once merged, every condition must name a product (e.g. you
+        // can't just specify an item or metric).
+        for(let cond of conds) {
+            if (cond.product === undefined) {
+                this.throwUnsupportedFilter(undefined, 'item/metric condition without product');
+            }
+        }
+
+        return merged;
+    },
 });
 
 module.exports = FilterCloudWatchCompiler;

--- a/lib/filter-cloudwatch-compiler.js
+++ b/lib/filter-cloudwatch-compiler.js
@@ -38,6 +38,12 @@ var _ = require('underscore');
 //    - AND can only be used to combine one product, one metric, and/or one item.
 //    - Other boolean logic is not supported.
 
+const CONDITION_KEYS = [
+    'product',
+    'item',
+    'metric'
+];
+
 var FilterCloudWatchCompiler = ASTVisitor.extend({
     initialize: function(options) {
         this.supported_products = options.supported_products;
@@ -114,13 +120,11 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
                     this.throwUnsupportedFilter(node.location, 'AND between products');
                 }
 
-                if ((left.item.length > 0 && right.item.length > 0)) {
-                    this.throwUnsupportedFilter(node.location, 'AND between items');
-                }
-
-                if ((left.metric.length > 0 && right.metric.length > 0)) {
-                    this.throwUnsupportedFilter(node.location, 'AND between metrics');
-                }
+                _.each(['item', 'metric'], (type) => {
+                    if ((left[type].length > 0 && right[type].length > 0)) {
+                        this.throwUnsupportedFilter(node.location, `AND between ${type}s`);
+                    }
+                });
 
                 // merge the two halves by combining the objects.
                 ret = [{
@@ -147,7 +151,7 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
                 // Left *must* be either 'item', 'product', or
                 // 'metric'. When left is 'product', right must be one
                 // of the supported AWS products.
-                if (left !== 'item' && left !== 'product' && left !== 'metric') {
+                if (CONDITION_KEYS.indexOf(left) < 0) {
                     this.throwUnsupportedFilter(node.location, 'condition ' + left);
                 }
 

--- a/lib/read.js
+++ b/lib/read.js
@@ -76,10 +76,13 @@ class ReadCloudWatch extends AdapterRead {
 
         // Create a object mapping from product to (empty) list of ids.
 
-        this._filter_search_expr = {};
-        for (let product of _.keys(PRODUCTS)) {
-            this._filter_search_expr[product] = [];
-        }
+        this._filter_search_expr = _.map(PRODUCTS, (value, key) => {
+            return {
+                product: key,
+                item: [],
+                metric: []
+            };
+        });
 
         if (params.filter_ast) {
             this.logger.debug('Filter ast: ', params.filter_ast);
@@ -90,24 +93,12 @@ class ReadCloudWatch extends AdapterRead {
             this.logger.debug('Filter expression: ', this._filter_search_expr);
         }
 
-        // Add the item name and product name to the filter expression.
-        this._filter_search_expr = _.mapObject(this._filter_search_expr, (item_ids, product) => {
-            return {
-                product: product,
-                item_name: PRODUCTS[product],
-                item_ids: item_ids
-            };
-        });
-
-        this.logger.debug('Enabled Products:', _.keys(this._filter_search_expr));
-
-        // Take the set of aws products and for the enabled plugins
-        // start monitoring the products in Cloudwatch.
         this._cloudwatch = new CloudWatchMon({AWS: AWS,
+                                              products: PRODUCTS,
                                               logger: this.logger,
                                               period: this._period,
                                               statistics: this._statistics,
-                                              monitor: _.values(this._filter_search_expr)});
+                                              conditions: this._filter_search_expr});
     }
 
     start() {

--- a/test/cloudwatch-adapter.spec.js
+++ b/test/cloudwatch-adapter.spec.js
@@ -273,6 +273,19 @@ describe('cloudwatch adapter', function() {
             });
         });
 
+        it(' using EC2 and metric="CPUUtilization", statistics=Minimum', function() {
+            return check_juttle({
+                program: 'read cloudwatch -statistics ["Minimum"] product="EC2" AND metric="CPUUtilization" | view text'
+            })
+            .then(function(result) {
+                expect(result.errors).to.have.length(0);
+                expect(result.warnings).to.have.length(0);
+                for(let point of result.sinks.text) {
+                    validate_point(point, ['Minimum']);
+                }
+            });
+        });
+
         it(' using ELB, statistics=Average,Minimum', function() {
             return check_juttle({
                 program: 'read cloudwatch -statistics ["Minimum", "Average"] product="ELB" | view text'


### PR DESCRIPTION
While working on the example programs for AWS/Cloudwatch, I found that
the Cloudwatch reads were pretty slow, as they had to fetch all
metrics, even if the read was really only interested in a single
metric like CPUUtilization.

To address this, add support for metrics in filtering expessions in
addition to items. This required a rework of FilterCloudWatchCompiler
to move beyond just a simple list of product= or item= filters. The
filtering expression now supports using AND to combine a
product=<product>, item=<item>, and/or metric=<metric> selector
together into a single condition. You can still use a concise format
of item=<product>:<item> or metric=<product>:<metric>, which is
essentially shorthand for product=<product> AND item=<item>. OR is
used to build up a list of conditions.

Within CloudWatchMon, it's given a list of conditions instead of a
list of products, as a product may appear in multiple conditions. If a
condition has a list of metrics, it is used to filter down the result
from listMetrics to only the desired metrics before calling
getMetricStatistics.

Add a bunch of unit tests that test all the new negative and positive
cases this introduces. While doing this, I found that some of the
negative tests were not actually working. In cases where the incorrect
filtering expression falsely compiled successfully, it wouldn't throw
an error at all and as a result wouldn't get to the expects() in the
catch handler. Fix that by throwing an error if compile doesn't.

@VladVega @davidvgalbraith 