### PR TITLE
Update for Juttle 0.5.0

### DIFF
--- a/lib/CloudWatchMon.js
+++ b/lib/CloudWatchMon.js
@@ -1,7 +1,9 @@
 'use strict';
 var Promise = require('bluebird');
 var _ = require('underscore');
-var JuttleMoment = require('juttle/lib/moment/juttle-moment');
+
+/* global JuttleAdapterAPI */
+var JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
 
 class CloudWatchMon {
 

--- a/lib/filter-cloudwatch-compiler.js
+++ b/lib/filter-cloudwatch-compiler.js
@@ -4,8 +4,8 @@
 //
 // The expression is returned from the compile method.
 
-var ASTVisitor = require('juttle/lib/compiler/ast-visitor');
-var JuttleErrors = require('juttle/lib/errors');
+/* global JuttleAdapterAPI */
+let StaticFilterCompiler = JuttleAdapterAPI.compiler.StaticFilterCompiler;
 var _ = require('underscore');
 
 // FilterCloudWatchCompiler derives from ASTVisitor which provides a way to
@@ -44,45 +44,30 @@ const CONDITION_KEYS = [
     'metric'
 ];
 
-var FilterCloudWatchCompiler = ASTVisitor.extend({
-    initialize: function(options) {
+class FilterCloudWatchCompiler extends StaticFilterCompiler {
+    constructor(options) {
+        super(options);
+
         this.supported_products = options.supported_products;
-    },
+    }
 
-    throwUnsupportedFilter(location, filter) {
-        throw JuttleErrors.compileError('RT-ADAPTER-UNSUPPORTED-FILTER', {
-            proc: 'read cloudwatch',
-            filter: filter,
-            location: location
-        });
-    },
-
-    compile: function(node) {
+    compile(node) {
         let conds = this.visit(node);
 
-        return this.merge(conds);
-    },
+        return this.merge(node, conds);
+    }
 
-    visitStringLiteral: function(node) {
+    visitStringLiteral(node) {
         return node.value;
-    },
+    }
 
-    visitSimpleFilterTerm: function(node) {
+    visitSimpleFilterTerm(node) {
         this.throwUnsupportedFilter(node.location, 'simple filter terms');
-    },
+    }
 
-    visitUnaryExpression: function(node) {
-        switch (node.operator) {
-            // '*' is the field dereferencing operator. For example,
-            // given a search string product = 'CloudWatch', the UnaryExpression
-            // * on product means 'the field called product'.
-            case '*':
-                return this.visit(node.expression);
-
-            default:
-                this.throwUnsupportedFilter(node.location, 'operator ' + node.operator);
-        }
-    },
+    visitField(node) {
+        return node.name;
+    }
 
     // Build up a list of conditions that control what metrics to
     // fetch. Each item in the array specifies conditions on:
@@ -97,7 +82,7 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
     // ANDs are used to combine incomplete conditions and ORs are used
     // to add to the list of conditions.
 
-    visitBinaryExpression: function(node) {
+    visitBinaryExpression(node) {
         var left, right, ret;
 
         switch (node.operator) {
@@ -108,7 +93,7 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
 
                 // You can only combine single conditions
                 if (left.length > 1 || right.length > 1) {
-                    this.throwUnsupportedFilter(node.location, 'AND between anything other than simple conditions');
+                    this.featureNotSupported(node, 'AND between anything other than simple conditions');
                 }
                 left = left[0];
                 right = right[0];
@@ -117,12 +102,12 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
                 // is wildcarded (undefined for products, an empty array for items/metrics).
                 if (left.product !== undefined &&
                     right.product !== undefined) {
-                    this.throwUnsupportedFilter(node.location, 'AND between products');
+                    this.featureNotSupported(node, 'AND between products');
                 }
 
                 _.each(['item', 'metric'], (type) => {
                     if ((left[type].length > 0 && right[type].length > 0)) {
-                        this.throwUnsupportedFilter(node.location, `AND between ${type}s`);
+                        this.featureNotSupported(node, `AND between ${type}s`);
                     }
                 });
 
@@ -152,7 +137,7 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
                 // 'metric'. When left is 'product', right must be one
                 // of the supported AWS products.
                 if (CONDITION_KEYS.indexOf(left) < 0) {
-                    this.throwUnsupportedFilter(node.location, 'condition ' + left);
+                    this.featureNotSupported(node, 'condition ' + left);
                 }
 
                 // for items/metrics, support a shorthand format '<aws
@@ -181,7 +166,7 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
 
                 // If product was set, it can only be a supported product
                 if (ret.product && ! _.contains(this.supported_products, ret.product)) {
-                    this.throwUnsupportedFilter(node.location, 'product ' + ret.product);
+                    this.featureNotSupported(node, 'product ' + ret.product);
                 }
 
                 ret = [ret];
@@ -189,15 +174,11 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
                 break;
 
             default:
-                this.throwUnsupportedFilter(node.location, 'operator ' + node.operator);
+                this.featureNotSupported(node, 'operator ' + node.operator);
         }
 
         return ret;
-    },
-
-    visitExpressionFilterTerm: function(node) {
-        return this.visit(node.expression);
-    },
+    }
 
     // Not inherited from ASTVisitor below here.
     can_merge(cond1, cond2) {
@@ -224,13 +205,13 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
 
         // The conditions can be merged.
         return true;
-    },
+    }
 
     // Given a list of conditions, try to merge them. This involves
     // finding conditions where the products are the same and the set
     // of metrics/items do not overlap.
 
-    merge(conds) {
+    merge(node, conds) {
         let merged = [];
 
         if (conds === undefined) {
@@ -257,12 +238,12 @@ var FilterCloudWatchCompiler = ASTVisitor.extend({
         // can't just specify an item or metric).
         for(let cond of conds) {
             if (cond.product === undefined) {
-                this.throwUnsupportedFilter(undefined, 'item/metric condition without product');
+                this.featureNotSupported(node, 'item/metric condition without product');
             }
         }
 
         return merged;
-    },
-});
+    }
+}
 
 module.exports = FilterCloudWatchCompiler;

--- a/lib/read.js
+++ b/lib/read.js
@@ -1,11 +1,13 @@
 'use strict';
 var AWS = require('aws-sdk');
+
+/* global JuttleAdapterAPI */
+var AdapterRead = JuttleAdapterAPI.AdapterRead;
+var JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
+
 var CloudWatchMon = require('./CloudWatchMon');
-var AdapterRead = require('juttle/lib/runtime/adapter-read');
-var errors = require('juttle/lib/errors');
 var _ = require('underscore');
 var FilterCloudWatchCompiler = require('./filter-cloudwatch-compiler');
-var JuttleMoment = require('juttle/lib/moment/juttle-moment');
 
 // By default, if a read command contains an -every less than 5
 // minutes, the adapter logs a warning, and if a read command contains
@@ -34,14 +36,14 @@ const PRODUCTS = {
 class ReadCloudWatch extends AdapterRead {
     periodicLiveRead() { return true;}
 
-    defaultTimeRange() {
+    defaultTimeOptions() {
         return {
             from: this.params.now.subtract(JuttleMoment.duration(10, 'm')),
             to: this.params.now
         };
     }
 
-    allowedOptions() {
+    static allowedOptions() {
         return AdapterRead.commonOptions().concat(['period', 'statistics']);
     }
 
@@ -59,9 +61,9 @@ class ReadCloudWatch extends AdapterRead {
         if (this.options.every &&
             this.options.every.lt(JuttleMoment.duration(1, 'm')) &&
             ! disable_every_errors) {
-            throw new errors.compileError('RT-ADAPTER-UNSUPPORTED-TIME-OPTION',
-                                          {proc: 'read cloudwatch', option: 'every',
-                                           message: '-every can not be less than 1 minute'});
+            throw this.compileError('ADAPTER-UNSUPPORTED-TIME-OPTION',
+                                   {option: 'every',
+                                    message: '-every can not be less than 1 minute'});
         }
 
         this._period = 60;

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "istanbul": "^0.4.2",
     "mocha": "^2.3.4"
   },
+  "juttleAdapterAPI": "^0.5.0",
   "engines": {
     "node": ">=4.2.0",
     "npm": ">=2.14.7"

--- a/test/filter-cloudwatch-compiler.spec.js
+++ b/test/filter-cloudwatch-compiler.spec.js
@@ -1,511 +1,518 @@
 'use strict';
 var JuttleParser = require('juttle/lib/parser');
 var SemanticPass = require('juttle/lib/compiler/semantic');
-var JuttleErrors = require('juttle/lib/errors');
-var JuttleMoment = require('juttle/lib/moment').JuttleMoment;
-var FilterCloudWatchCompiler = require('../lib/filter-cloudwatch-compiler');
+var FilterSimplifier = require('juttle/lib/compiler/filters/filter-simplifier');
 var expect = require('chai').expect;
+var withAdapterAPI = require('juttle/test').utils.withAdapterAPI;
 
-function verify_compile_error(source, filter) {
-    var ast = JuttleParser.parseFilter(source).ast;
+withAdapterAPI(() => {
 
-    var semantic = new SemanticPass({ now: new JuttleMoment() });
-    semantic.sa_expr(ast);
+    /* global JuttleAdapterAPI */
+    let JuttleMoment = JuttleAdapterAPI.types.JuttleMoment;
+    let JuttleErrors = JuttleAdapterAPI.errors;
+    let FilterCloudWatchCompiler = require('../lib/filter-cloudwatch-compiler');
+    let simplifier = new FilterSimplifier();
 
-    var compiler = compiler || new FilterCloudWatchCompiler({
-        supported_products: ['EC2', 'EBS', 'RDS']
-    });
+    function verify_compile_error(source, feature) {
+        var ast = JuttleParser.parseFilter(source).ast;
 
-    try {
-        compiler.compile(ast);
-        throw new Error('Compile succeeded when it should have failed');
-    } catch (e) {
-        expect(e).to.be.instanceOf(JuttleErrors.CompileError);
-        expect(e.code).to.equal('RT-ADAPTER-UNSUPPORTED-FILTER');
-        expect(e.info.filter).to.equal(filter);
+        var semantic = new SemanticPass({ now: new JuttleMoment() });
+        semantic.sa_expr(ast);
+
+        ast = simplifier.simplify(ast);
+
+        var compiler = compiler || new FilterCloudWatchCompiler({
+            supported_products: ['EC2', 'EBS', 'RDS']
+        });
+
+        try {
+            compiler.compile(ast);
+            throw new Error('Compile succeeded when it should have failed');
+        } catch (e) {
+            expect(e).to.be.instanceOf(JuttleErrors.CompileError);
+            expect(e.code).to.equal('FILTER-FEATURE-NOT-SUPPORTED');
+            expect(e.info.feature).to.equal(feature);
+        }
     }
-}
 
-function verify_compile_success(source, expected) {
-    var ast = JuttleParser.parseFilter(source).ast;
+    function verify_compile_success(source, expected) {
+        var ast = JuttleParser.parseFilter(source).ast;
 
-    var semantic = new SemanticPass({ now: new JuttleMoment() });
-    semantic.sa_expr(ast);
+        var semantic = new SemanticPass({ now: new JuttleMoment() });
+        semantic.sa_expr(ast);
 
-    var compiler = new FilterCloudWatchCompiler({
-        supported_products: ['EC2', 'EBS', 'RDS']
-    });
+        ast = simplifier.simplify(ast);
 
-    var search_expr = compiler.compile(ast);
-    expect(search_expr).to.deep.equal(expected);
-}
+        var compiler = new FilterCloudWatchCompiler({
+            supported_products: ['EC2', 'EBS', 'RDS']
+        });
 
-describe('aws filter', function() {
+        var search_expr = compiler.compile(ast);
+        expect(search_expr).to.deep.equal(expected);
+    }
 
-    describe('properly returns errors for invalid filtering expressions like', function() {
+    describe('aws filter', function() {
 
-        var invalid_unary_operators = ['!', '-'];
+        describe('properly returns errors for invalid filtering expressions like', function() {
 
-        invalid_unary_operators.forEach(function(op) {
-            it('using unary operator ' + op + ' in field specifications', function() {
-                verify_compile_error('product = ' + op + ' "foo"',
-                                     'operator ' + op);
+            var invalid_unary_operators = ['!', '-'];
+
+            invalid_unary_operators.forEach(function(op) {
+                it('using unary operator ' + op + ' in field specifications', function() {
+                    verify_compile_error('product = ' + op + ' "foo"',
+                                         `the "${op}" operator`);
+                });
+            });
+
+            var invalid_operators = ['=~', '!~', '<', '<=', '>', '>=', 'in'];
+            invalid_operators.forEach(function(op) {
+                it('using ' + op + ' in field comparisons', function() {
+                    verify_compile_error('product ' + op + ' "foo"',
+                                         'operator ' + op);
+                });
+            });
+
+            it('Combining products with AND', function() {
+                verify_compile_error('product="EC2" AND product="EBS"',
+                                     'AND between products');
+            });
+
+            it('Combining items with AND', function() {
+                verify_compile_error('product="EC2" AND item="i-cb955911" AND item="i-966a694d"',
+                                     'AND between items');
+            });
+
+            it('Combining items with AND (using concise item notation)', function() {
+                verify_compile_error('item="EC2:i-cb955911" AND item="EC2:i-966a694d"',
+                                     'AND between products');
+            });
+
+            it('Combining product and item with AND', function() {
+                verify_compile_error('product="EC2" AND item="EC2:i-cb955911"',
+                                     'AND between products');
+            });
+
+            it('Combining product and item with AND (different products)', function() {
+                verify_compile_error('product="EC2" AND item="EBS:vol-56130db1"',
+                                     'AND between products');
+            });
+
+            it('Combining product and metric with AND', function() {
+                verify_compile_error('product="EC2" AND metric="EC2:DiskReadBytes"',
+                                     'AND between products');
+            });
+
+            it('Combining product and metric with AND (different products)', function() {
+                verify_compile_error('product="EC2" AND metric="EBS:DiskReadBytes"',
+                                     'AND between products');
+            });
+
+            it('Combining product, metric and item with AND (different products)', function() {
+                verify_compile_error('product="EBS" AND metric="DiskReadBytes" and item="EC2:i-cb955911"',
+                                     'AND between products');
+            });
+
+            it('Combining metrics with AND', function() {
+                verify_compile_error('product="EC2" AND metric="CPUUtilization" AND metric="DiskReadOps"',
+                                     'AND between metrics');
+            });
+
+            it('Combining metrics with AND (concise notation)', function() {
+                verify_compile_error('metric="EC2:CPUUtilization" AND metric="EC2:DiskReadOps"',
+                                     'AND between products');
+            });
+
+            it('Combining groups of ORs with AND (on one side)', function() {
+                verify_compile_error('(product="EC2" OR product="EBS") AND product="RDS"',
+                                     'AND between anything other than simple conditions');
+            });
+
+            it('Combining groups of ORs with AND (on both sides)', function() {
+                verify_compile_error('(product="EC2" OR product="EBS") AND (product="RDS" OR product="EC2")',
+                                     'AND between anything other than simple conditions');
+            });
+
+            it('Nested ANDs and ORs)', function() {
+                verify_compile_error('(metric="DiskReadBytes" OR metric="DiskWriteBytes") AND (metric="NetworkIn" OR metric="NetworkOut")',
+                                     'AND between anything other than simple conditions');
+            });
+
+            it('Combining groups of item ORs with AND)', function() {
+                verify_compile_error('(item="i-cb955911" OR item="i-11cb9559") AND (item="i-cc696a17" OR item="i-17cc696a")',
+                                     'AND between anything other than simple conditions');
+            });
+
+            it('Combining nested groups of ORs with AND', function() {
+                verify_compile_error('((product="EC2" AND item="i-cb955911") OR (product="EC2" and item="i-11cb9559")) AND ((product="RDS" AND item="db-production") OR (product="EBS" and metric="DiskWriteBytes"))',
+                                     'AND between anything other than simple conditions');
+            });
+
+            it('Using NOT on a term', function() {
+                verify_compile_error('NOT product="EC2"',
+                                     'the "NOT" operator');
+            });
+
+            it('A filter term not containing "item" or "product"', function() {
+                verify_compile_error('foo="EC2"',
+                                     'condition foo');
+            });
+
+            it('matching on unsupported products', function() {
+                verify_compile_error('product = "Lambda"',
+                                     'product Lambda');
+            });
+
+            it('item in filter without any corresponding product', function() {
+                verify_compile_error('item = "i-cb955911"',
+                                     'item/metric condition without product');
+            });
+
+            it('metric in filter without any corresponding product', function() {
+                verify_compile_error('metric = "DiskReadBytes"',
+                                     'item/metric condition without product');
+            });
+
+            it('item in filter for unsupported product', function() {
+                verify_compile_error('item = "NOPRODUCT:i-cb955911"',
+                                     'product NOPRODUCT');
+            });
+
+            it('a single filter expression', function() {
+                verify_compile_error('\"foo\"',
+                                     'fulltext search');
             });
         });
 
-        var invalid_operators = ['=~', '!~', '<', '<=', '>', '>=', 'in'];
-        invalid_operators.forEach(function(op) {
-            it('using ' + op + ' in field comparisons', function() {
-                verify_compile_error('product ' + op + ' "foo"',
-                                     'operator ' + op);
+        describe('properly returns condition lists for valid cases like', function() {
+            it('Single product match', function() {
+                verify_compile_success('product="EC2"', [{
+                    product: 'EC2',
+                    item: [],
+                    metric: []
+                }]);
             });
+
+            it('Multiple product matches', function() {
+                verify_compile_success('product="EC2" OR product="EBS"', [
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: []
+                    },
+                    {
+                        product: 'EBS',
+                        item: [],
+                        metric: []
+                    }
+                ]);
+            });
+
+            it('Multiple product matches w/ duplicates', function() {
+                verify_compile_success('product="EC2" OR product="EC2"', [
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: []
+                    },
+                ]);
+            });
+
+            it('Multiple product matches, not adjacent', function() {
+                verify_compile_success('product="EC2" OR product="EBS" OR product="EC2"', [
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: []
+                    },
+                    {
+                        product: 'EBS',
+                        item: [],
+                        metric: []
+                    },
+                ]);
+            });
+
+            it('Single item match', function() {
+                verify_compile_success('item="EC2:i-cc696a17"', [
+                    {
+                        product: 'EC2',
+                        item: ['i-cc696a17'],
+                        metric: []
+                    }
+                ]);
+            });
+
+            it('Multiple item matches', function() {
+                verify_compile_success('item="EC2:i-cc696a17" OR item="EBS:vol-56130db1"', [
+                    {
+                        product: 'EC2',
+                        item: ['i-cc696a17'],
+                        metric: []
+                    },
+                    {
+                        product: 'EBS',
+                        item: ['vol-56130db1'],
+                        metric: []
+                    }
+                ]);
+            });
+
+            it('Multiple item matches for same product', function() {
+                verify_compile_success('item="EC2:i-cc696a17" OR item="EC2:i-966a694d"', [
+                    {
+                        product: 'EC2',
+                        item: ['i-cc696a17', 'i-966a694d'],
+                        metric: []
+                    }
+                ]);
+            });
+
+            it('Multiple item matches with duplicates', function() {
+                verify_compile_success('item="EC2:i-cc696a17" OR item="EC2:i-cc696a17"', [
+                    {
+                        product: 'EC2',
+                        item: ['i-cc696a17'],
+                        metric: []
+                    }
+                ]);
+            });
+
+            it('Single metric match', function() {
+                verify_compile_success('metric="EC2:CPUUtilization"', [
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: ['CPUUtilization']
+                    }
+                ]);
+            });
+
+            it('Multiple metric matches', function() {
+                verify_compile_success('metric="EC2:CPUUtilization" OR metric="EBS:VolumeReadBytes"', [
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: ['CPUUtilization']
+                    },
+                    {
+                        product: 'EBS',
+                        item: [],
+                        metric: ['VolumeReadBytes']
+                    }
+                ]);
+
+            });
+
+            it('Multiple metric matches for same product', function() {
+                verify_compile_success('metric="EC2:CPUUtilization" OR metric="EC2:DiskReadOps"', [
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: ['CPUUtilization', 'DiskReadOps']
+                    }
+                ]);
+            });
+
+            it('Multiple item matches with duplicates', function() {
+                verify_compile_success('metric="EC2:CPUUtilization" OR metric="EC2:CPUUtilization"', [
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: ['CPUUtilization']
+                    }
+                ]);
+            });
+
+            it('Combining product and metrics with AND', function() {
+                verify_compile_success('product="EC2" AND metric="DiskReadOps"', [
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: ['DiskReadOps']
+                    }
+                ]);
+            });
+
+            it('Combining products, metrics, and items with AND', function() {
+                verify_compile_success('product="EC2" AND item="i-cb955911" AND metric="DiskReadOps"', [
+                    {
+                        product: 'EC2',
+                        item: ['i-cb955911'],
+                        metric: ['DiskReadOps']
+                    }
+                ]);
+            });
+
+            it('Combining products, metrics, and items with AND (concise notation)', function() {
+                verify_compile_success('item="EC2:i-cb955911" AND metric="DiskReadOps"', [
+                    {
+                        product: 'EC2',
+                        item: ['i-cb955911'],
+                        metric: ['DiskReadOps']
+                    }
+                ]);
+            });
+
+            it('Combining products, metrics, and items with AND, along with unrelated products', function() {
+                verify_compile_success('item="EC2:i-cb955911" AND metric="DiskReadOps" OR product="EBS" OR product="RDS"', [
+                    {
+                        product: 'EC2',
+                        item: ['i-cb955911'],
+                        metric: ['DiskReadOps']
+                    },
+                    {
+                        product: 'EBS',
+                        item: [],
+                        metric: []
+                    },
+                    {
+                        product: 'RDS',
+                        item: [],
+                        metric: []
+                    }
+                ]);
+            });
+
+            it('Combining groups of products/metrics/items combined with AND', function() {
+                verify_compile_success('(product="EC2" AND item="i-cb955911" AND metric="DiskReadOps") OR (product="EBS" and metric="DiskWriteBytes") OR (product="RDS" and item="db-production")', [
+                    {
+                        product: 'EC2',
+                        item: ['i-cb955911'],
+                        metric: ['DiskReadOps']
+                    },
+                    {
+                        product: 'EBS',
+                        item: [],
+                        metric: ['DiskWriteBytes']
+                    },
+                    {
+                        product: 'RDS',
+                        item: ['db-production'],
+                        metric: []
+                    }
+                ]);
+            });
+
+            it('Separate product items can be merged', function() {
+                verify_compile_success('(product="EC2" AND item="i-cb955911") OR product="RDS" OR (product="EC2" AND item="i-cc696a17")', [
+                    {
+                        product: 'EC2',
+                        item: ['i-cb955911', 'i-cc696a17'],
+                        metric: []
+                    },
+                    {
+                        product: 'RDS',
+                        item: [],
+                        metric: []
+                    }
+                ]);
+            });
+
+            it('Single and wildcard product items will not be merged', function() {
+                verify_compile_success('product="EC2" OR product="RDS" OR (product="EC2" AND item="i-cc696a17")', [
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: []
+                    },
+                    {
+                        product: 'RDS',
+                        item: [],
+                        metric: []
+                    },
+                    {
+                        product: 'EC2',
+                        item: ['i-cc696a17'],
+                        metric: []
+                    },
+                ]);
+            });
+
+            it('Single and wildcard product metrics will not be merged', function() {
+                verify_compile_success('product="EC2" OR product="RDS" OR (product="EC2" AND metric="CPUUtilization")', [
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: []
+                    },
+                    {
+                        product: 'RDS',
+                        item: [],
+                        metric: []
+                    },
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: ['CPUUtilization']
+                    },
+                ]);
+            });
+
+            it('Separate product metrics can be merged', function() {
+                verify_compile_success('(product="EBS" AND metric="DiskReadBytes") OR product="EC2" OR (product="EBS" AND metric="DiskWriteBytes")', [
+                    {
+                        product: 'EBS',
+                        item: [],
+                        metric: ['DiskReadBytes', 'DiskWriteBytes']
+                    },
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: []
+                    }
+                ]);
+            });
+
+            it('Separate product items/metric conditions will not be merged', function() {
+                verify_compile_success('(product="EC2" AND item="i-cb955911") OR product="RDS" OR (product="EC2" AND metric="CPUUtilization")', [
+                    {
+                        product: 'EC2',
+                        item: ['i-cb955911'],
+                        metric: []
+                    },
+                    {
+                        product: 'RDS',
+                        item: [],
+                        metric: []
+                    },
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: ['CPUUtilization']
+                    }
+                ]);
+            });
+
+            it('Mix of item and product matches', function() {
+                verify_compile_success('product="EC2" OR product="EBS" OR item="EC2:i-cc696a17" OR item="EC2:i-966a694d" OR item="EBS:vol-56130db1" OR product="RDS"', [
+                    {
+                        product: 'EC2',
+                        item: [],
+                        metric: []
+                    },
+                    {
+                        product: 'EBS',
+                        item: [],
+                        metric: []
+                    },
+                    {
+                        product: 'EC2',
+                        item: ['i-cc696a17', 'i-966a694d'],
+                        metric: []
+                    },
+                    {
+                        product: 'EBS',
+                        item: ['vol-56130db1'],
+                        metric: []
+                    },
+                    {
+                        product: 'RDS',
+                        item: [],
+                        metric: []
+                    }
+                ]);
+            });
+
         });
-
-        it('Combining products with AND', function() {
-            verify_compile_error('product="EC2" AND product="EBS"',
-                                 'AND between products');
-        });
-
-        it('Combining items with AND', function() {
-            verify_compile_error('product="EC2" AND item="i-cb955911" AND item="i-966a694d"',
-                                 'AND between items');
-        });
-
-        it('Combining items with AND (using concise item notation)', function() {
-            verify_compile_error('item="EC2:i-cb955911" AND item="EC2:i-966a694d"',
-                                 'AND between products');
-        });
-
-        it('Combining product and item with AND', function() {
-            verify_compile_error('product="EC2" AND item="EC2:i-cb955911"',
-                                 'AND between products');
-        });
-
-        it('Combining product and item with AND (different products)', function() {
-            verify_compile_error('product="EC2" AND item="EBS:vol-56130db1"',
-                                 'AND between products');
-        });
-
-        it('Combining product and metric with AND', function() {
-            verify_compile_error('product="EC2" AND metric="EC2:DiskReadBytes"',
-                                 'AND between products');
-        });
-
-        it('Combining product and metric with AND (different products)', function() {
-            verify_compile_error('product="EC2" AND metric="EBS:DiskReadBytes"',
-                                 'AND between products');
-        });
-
-        it('Combining product, metric and item with AND (different products)', function() {
-            verify_compile_error('product="EBS" AND metric="DiskReadBytes" and item="EC2:i-cb955911"',
-                                 'AND between products');
-        });
-
-        it('Combining metrics with AND', function() {
-            verify_compile_error('product="EC2" AND metric="CPUUtilization" AND metric="DiskReadOps"',
-                                 'AND between metrics');
-        });
-
-        it('Combining metrics with AND (concise notation)', function() {
-            verify_compile_error('metric="EC2:CPUUtilization" AND metric="EC2:DiskReadOps"',
-                                 'AND between products');
-        });
-
-        it('Combining groups of ORs with AND (on one side)', function() {
-            verify_compile_error('(product="EC2" OR product="EBS") AND product="RDS"',
-                                 'AND between anything other than simple conditions');
-        });
-
-        it('Combining groups of ORs with AND (on both sides)', function() {
-            verify_compile_error('(product="EC2" OR product="EBS") AND (product="RDS" OR product="EC2")',
-                                 'AND between anything other than simple conditions');
-        });
-
-        it('Nested ANDs and ORs)', function() {
-            verify_compile_error('(metric="DiskReadBytes" OR metric="DiskWriteBytes") AND (metric="NetworkIn" OR metric="NetworkOut")',
-                                 'AND between anything other than simple conditions');
-        });
-
-        it('Combining groups of item ORs with AND)', function() {
-            verify_compile_error('(item="i-cb955911" OR item="i-11cb9559") AND (item="i-cc696a17" OR item="i-17cc696a")',
-                                 'AND between anything other than simple conditions');
-        });
-
-        it('Combining nested groups of ORs with AND', function() {
-            verify_compile_error('((product="EC2" AND item="i-cb955911") OR (product="EC2" and item="i-11cb9559")) AND ((product="RDS" AND item="db-production") OR (product="EBS" and metric="DiskWriteBytes"))',
-                                 'AND between anything other than simple conditions');
-        });
-
-        it('Using NOT on a term', function() {
-            verify_compile_error('NOT product="EC2"',
-                                 'operator NOT');
-        });
-
-        it('A filter term not containing "item" or "product"', function() {
-            verify_compile_error('foo="EC2"',
-                                 'condition foo');
-        });
-
-        it('matching on unsupported products', function() {
-            verify_compile_error('product = "Lambda"',
-                                 'product Lambda');
-        });
-
-        it('item in filter without any corresponding product', function() {
-            verify_compile_error('item = "i-cb955911"',
-                                 'item/metric condition without product');
-        });
-
-        it('metric in filter without any corresponding product', function() {
-            verify_compile_error('metric = "DiskReadBytes"',
-                                 'item/metric condition without product');
-        });
-
-        it('item in filter for unsupported product', function() {
-            verify_compile_error('item = "NOPRODUCT:i-cb955911"',
-                                 'product NOPRODUCT');
-        });
-
-        it('a single filter expression', function() {
-            verify_compile_error('\"foo\"',
-                                 'simple filter terms');
-        });
-
-        it('not a filter expression or string', function() {
-            verify_compile_error('+ 1',
-                                 'simple filter terms');
-        });
-    });
-
-    describe('properly returns condition lists for valid cases like', function() {
-        it('Single product match', function() {
-            verify_compile_success('product="EC2"', [{
-                product: 'EC2',
-                item: [],
-                metric: []
-            }]);
-        });
-
-        it('Multiple product matches', function() {
-            verify_compile_success('product="EC2" OR product="EBS"', [
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: []
-                },
-                {
-                    product: 'EBS',
-                    item: [],
-                    metric: []
-                }
-            ]);
-        });
-
-        it('Multiple product matches w/ duplicates', function() {
-            verify_compile_success('product="EC2" OR product="EC2"', [
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: []
-                },
-            ]);
-        });
-
-        it('Multiple product matches, not adjacent', function() {
-            verify_compile_success('product="EC2" OR product="EBS" OR product="EC2"', [
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: []
-                },
-                {
-                    product: 'EBS',
-                    item: [],
-                    metric: []
-                },
-            ]);
-        });
-
-        it('Single item match', function() {
-            verify_compile_success('item="EC2:i-cc696a17"', [
-                {
-                    product: 'EC2',
-                    item: ['i-cc696a17'],
-                    metric: []
-                }
-            ]);
-        });
-
-        it('Multiple item matches', function() {
-            verify_compile_success('item="EC2:i-cc696a17" OR item="EBS:vol-56130db1"', [
-                {
-                    product: 'EC2',
-                    item: ['i-cc696a17'],
-                    metric: []
-                },
-                {
-                    product: 'EBS',
-                    item: ['vol-56130db1'],
-                    metric: []
-                }
-            ]);
-        });
-
-        it('Multiple item matches for same product', function() {
-            verify_compile_success('item="EC2:i-cc696a17" OR item="EC2:i-966a694d"', [
-                {
-                    product: 'EC2',
-                    item: ['i-cc696a17', 'i-966a694d'],
-                    metric: []
-                }
-            ]);
-        });
-
-        it('Multiple item matches with duplicates', function() {
-            verify_compile_success('item="EC2:i-cc696a17" OR item="EC2:i-cc696a17"', [
-                {
-                    product: 'EC2',
-                    item: ['i-cc696a17'],
-                    metric: []
-                }
-            ]);
-        });
-
-        it('Single metric match', function() {
-            verify_compile_success('metric="EC2:CPUUtilization"', [
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: ['CPUUtilization']
-                }
-            ]);
-        });
-
-        it('Multiple metric matches', function() {
-            verify_compile_success('metric="EC2:CPUUtilization" OR metric="EBS:VolumeReadBytes"', [
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: ['CPUUtilization']
-                },
-                {
-                    product: 'EBS',
-                    item: [],
-                    metric: ['VolumeReadBytes']
-                }
-            ]);
-
-        });
-
-        it('Multiple metric matches for same product', function() {
-            verify_compile_success('metric="EC2:CPUUtilization" OR metric="EC2:DiskReadOps"', [
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: ['CPUUtilization', 'DiskReadOps']
-                }
-            ]);
-        });
-
-        it('Multiple item matches with duplicates', function() {
-            verify_compile_success('metric="EC2:CPUUtilization" OR metric="EC2:CPUUtilization"', [
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: ['CPUUtilization']
-                }
-            ]);
-        });
-
-        it('Combining product and metrics with AND', function() {
-            verify_compile_success('product="EC2" AND metric="DiskReadOps"', [
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: ['DiskReadOps']
-                }
-            ]);
-        });
-
-        it('Combining products, metrics, and items with AND', function() {
-            verify_compile_success('product="EC2" AND item="i-cb955911" AND metric="DiskReadOps"', [
-                {
-                    product: 'EC2',
-                    item: ['i-cb955911'],
-                    metric: ['DiskReadOps']
-                }
-            ]);
-        });
-
-        it('Combining products, metrics, and items with AND (concise notation)', function() {
-            verify_compile_success('item="EC2:i-cb955911" AND metric="DiskReadOps"', [
-                {
-                    product: 'EC2',
-                    item: ['i-cb955911'],
-                    metric: ['DiskReadOps']
-                }
-            ]);
-        });
-
-        it('Combining products, metrics, and items with AND, along with unrelated products', function() {
-            verify_compile_success('item="EC2:i-cb955911" AND metric="DiskReadOps" OR product="EBS" OR product="RDS"', [
-                {
-                    product: 'EC2',
-                    item: ['i-cb955911'],
-                    metric: ['DiskReadOps']
-                },
-                {
-                    product: 'EBS',
-                    item: [],
-                    metric: []
-                },
-                {
-                    product: 'RDS',
-                    item: [],
-                    metric: []
-                }
-            ]);
-        });
-
-        it('Combining groups of products/metrics/items combined with AND', function() {
-            verify_compile_success('(product="EC2" AND item="i-cb955911" AND metric="DiskReadOps") OR (product="EBS" and metric="DiskWriteBytes") OR (product="RDS" and item="db-production")', [
-                {
-                    product: 'EC2',
-                    item: ['i-cb955911'],
-                    metric: ['DiskReadOps']
-                },
-                {
-                    product: 'EBS',
-                    item: [],
-                    metric: ['DiskWriteBytes']
-                },
-                {
-                    product: 'RDS',
-                    item: ['db-production'],
-                    metric: []
-                }
-            ]);
-        });
-
-        it('Separate product items can be merged', function() {
-            verify_compile_success('(product="EC2" AND item="i-cb955911") OR product="RDS" OR (product="EC2" AND item="i-cc696a17")', [
-                {
-                    product: 'EC2',
-                    item: ['i-cb955911', 'i-cc696a17'],
-                    metric: []
-                },
-                {
-                    product: 'RDS',
-                    item: [],
-                    metric: []
-                }
-            ]);
-        });
-
-        it('Single and wildcard product items will not be merged', function() {
-            verify_compile_success('product="EC2" OR product="RDS" OR (product="EC2" AND item="i-cc696a17")', [
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: []
-                },
-                {
-                    product: 'RDS',
-                    item: [],
-                    metric: []
-                },
-                {
-                    product: 'EC2',
-                    item: ['i-cc696a17'],
-                    metric: []
-                },
-            ]);
-        });
-
-        it('Single and wildcard product metrics will not be merged', function() {
-            verify_compile_success('product="EC2" OR product="RDS" OR (product="EC2" AND metric="CPUUtilization")', [
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: []
-                },
-                {
-                    product: 'RDS',
-                    item: [],
-                    metric: []
-                },
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: ['CPUUtilization']
-                },
-            ]);
-        });
-
-        it('Separate product metrics can be merged', function() {
-            verify_compile_success('(product="EBS" AND metric="DiskReadBytes") OR product="EC2" OR (product="EBS" AND metric="DiskWriteBytes")', [
-                {
-                    product: 'EBS',
-                    item: [],
-                    metric: ['DiskReadBytes', 'DiskWriteBytes']
-                },
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: []
-                }
-            ]);
-        });
-
-        it('Separate product items/metric conditions will not be merged', function() {
-            verify_compile_success('(product="EC2" AND item="i-cb955911") OR product="RDS" OR (product="EC2" AND metric="CPUUtilization")', [
-                {
-                    product: 'EC2',
-                    item: ['i-cb955911'],
-                    metric: []
-                },
-                {
-                    product: 'RDS',
-                    item: [],
-                    metric: []
-                },
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: ['CPUUtilization']
-                }
-            ]);
-        });
-
-        it('Mix of item and product matches', function() {
-            verify_compile_success('product="EC2" OR product="EBS" OR item="EC2:i-cc696a17" OR item="EC2:i-966a694d" OR item="EBS:vol-56130db1" OR product="RDS"', [
-                {
-                    product: 'EC2',
-                    item: [],
-                    metric: []
-                },
-                {
-                    product: 'EBS',
-                    item: [],
-                    metric: []
-                },
-                {
-                    product: 'EC2',
-                    item: ['i-cc696a17', 'i-966a694d'],
-                    metric: []
-                },
-                {
-                    product: 'EBS',
-                    item: ['vol-56130db1'],
-                    metric: []
-                },
-                {
-                    product: 'RDS',
-                    item: [],
-                    metric: []
-                }
-            ]);
-        });
-
     });
 });


### PR DESCRIPTION
Access AdapterRead, JuttleMoment, StaticFilterCompiler etc through
JuttleAdapterAPI.

Don't include JuttleErrors unless necessary, relying on error method
in AdapterRead.

Use ES6 class for FilterCloudwatchCompiler derived from StaticFilterCompiler.

Use already-provided featureNotSupported to return errors.

Update filter parsing callbacks based on the advice in
https://github.com/juttle/juttle/wiki/Porting-Adapters-to-the-0.5.x-API.

Create the adapter in the test as suggested.

Note the juttleAdapterAPI dependency in package.json.

Rename defaultTimeRange() to defaultTimeOptions().

allowedOptions was mistakenly not static, so fix.

@VladVega @demmer @davidvgalbraith