### PR TITLE
Add ecosystem link to juttle-cloudwatch-adapter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,13 @@ the adapter need to be installed side-by-side:
 $ npm install juttle
 $ npm install juttle-cloudwatch-adapter
 ```
+
+## Ecosystem
+
+Here's how the juttle-cloudwatch-adapter module fits into the overall [Juttle Ecosystem](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md):
+
+[![Juttle Ecosystem](https://github.com/juttle/juttle/raw/master/docs/images/JuttleEcosystemDiagram.png)](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md)
+
 ## Configuration
 
 Configuration involves these steps:

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ $ npm install juttle-cloudwatch-adapter
 
 ## Ecosystem
 
-Here's how the juttle-cloudwatch-adapter module fits into the overall [Juttle Ecosystem](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md):
+The juttle-cloudwatch-adapter fits into the overall Juttle Ecosystem as one of the adapters in the [below diagram](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md):
 
 [![Juttle Ecosystem](https://github.com/juttle/juttle/raw/master/docs/images/JuttleEcosystemDiagram.png)](https://github.com/juttle/juttle/blob/master/docs/juttle_ecosystem.md)
 


### PR DESCRIPTION
Add an ecosystem section to each README to show its part in the
overall architecture.

@VladVega @davidvgalbraith 