### PR TITLE
Add new RDS cloudwatch metric.

### DIFF
--- a/test/cloudwatch-adapter.spec.js
+++ b/test/cloudwatch-adapter.spec.js
@@ -225,7 +225,8 @@ describe('cloudwatch adapter', function() {
 
                     // Not documented on RDS Cloudwatch API page, but
                     // adding here so validation will still pass
-                    TransactionLogsDiskUsage: {units: 'Bytes'}
+                    TransactionLogsDiskUsage: {units: 'Bytes'},
+                    OldestReplicationSlotLag: {units: 'Bytes'}
                 }
             };
 


### PR DESCRIPTION
The unit test started failing due to this probably new metric for RDS:
OldestReplicationSlotLag. It's not documented but is appearing in
results, so allow it.

This fixes #10.

@davidvgalbraith @VladVega @go-oleg 